### PR TITLE
copy in most unexported funs and hack environment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pwiser
 Title: Tidy P(air)wise Operations
-Version: 0.0.0.9000
+Version: 0.0.1.9000
 Authors@R: 
   c(person(given = "Bryan",
            family = "Shalloway",

--- a/R/context.R
+++ b/R/context.R
@@ -1,0 +1,40 @@
+
+# context accessors -------------------------------------------------------
+
+context_env <- dplyr:::context_env
+# context_env <- new_environment()
+context_poke <- function(name, value) {
+  old <- context_env[[name]]
+  context_env[[name]] <- value
+  old
+}
+context_peek_bare <- function(name) {
+  ### THIS IS A TOTAL HACK
+  ### also removes any safeguards around where is used
+  # context_env[[name]]
+  dplyr:::context_env[[name]]
+}
+
+context_peek <- function(name, fun, location = "dplyr verbs") {
+  context_peek_bare(name) %||%
+    abort(glue("`{fun}` must only be used inside {location}."))
+}
+context_local <- function(name, value, frame = caller_env()) {
+  old <- context_poke(name, value)
+  expr <- expr(on.exit(context_poke(!!name, !!old), add = TRUE))
+  eval_bare(expr, frame)
+}
+
+peek_column <- function() {
+  context_peek("column", "cur_column()", "`across()`")
+}
+local_column <- function(x, frame = caller_env()) {
+  context_local("column", x, frame = frame)
+}
+
+peek_mask <- function(fun = "peek_mask()") {
+  context_peek("mask", fun)
+}
+local_mask <- function(x, frame = caller_env()) {
+  context_local("mask", x, frame = frame)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -94,6 +94,10 @@ There are other tools in R for doing tidy pairwise operations. [widyr](https://g
 
 The novelty of `pwiser::pairwise()` is its integration in both mutating and summarising verbs in `{dplyr}`.
 
+**Identified after publishing {pwiser}:**
+
+The [dplyover](https://github.com/TimTeaFan/dplyover) package is a more mature package that also offers a wide range of extensions on `across()` for iteration problems. `dplyover::over2x()` can be used to do essentially the same thing as `pairwise()`. We are currently reviewing whether to mark {pwiser} as superseded so we can point people to {dplyover}.
+
 ## Computation Speed
 
 *For problems with lots of data you should use more efficient approaches.*
@@ -128,3 +132,7 @@ microbenchmark::microbenchmark(
 The `stats::cor()` and `corrr::correlate()` approaches are many times faster than using `pairwise()`. However `pairwise()` still only takes about one fifth of a second to calculate 1540 correlations in this case. Hence on relatively constrained problems pairwise() is still quite usable. (Though there are many cases where you should go for a matrix based solution.)
 
 `pairwise()` seems to be faster than `corrr::colpair_map()` (a more apples-to-apples comparison as both can handle arbitrary functions), though much of this speed difference goes away when `.is_commutative = FALSE`.
+
+# Limitations
+
+See issue [#1](https://github.com/brshallo/pwiser/issues/1) for a little on limitations in current set-up.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ for a few cataloged tweets on these approaches.)
 The novelty of `pwiser::pairwise()` is its integration in both mutating
 and summarising verbs in `{dplyr}`.
 
+**Identified after publishing {pwiser}:**
+
+The [dplyover](https://github.com/TimTeaFan/dplyover) package is a more
+mature package that also offers a wide range of extensions on `across()`
+for iteration problems. `dplyover::over2x()` can be used to do
+essentially the same thing as `pairwise()`. We are currently reviewing
+whether to mark {pwiser} as superseded so we can point people to
+{dplyover}.
+
 ## Computation Speed
 
 *For problems with lots of data you should use more efficient
@@ -173,16 +182,11 @@ microbenchmark::microbenchmark(
   times = 10L,
   unit = "ms")
 #> Unit: milliseconds
-#>         expr      min       lq       mean    median        uq       max neval
-#>          cor   4.9390   5.4155    6.59767   6.23110    7.1104   10.0226    10
-#>    correlate  42.0968  42.4645   56.14318  53.70095   67.0191   77.7793    10
-#>  colpair_map 786.2960 833.6539 1119.77656 844.24510 1177.1455 2314.8609    10
-#>     pairwise 255.8610 266.7864  321.14781 300.37675  345.9385  495.8805    10
-#>  cld
-#>   a 
-#>   a 
-#>    b
-#>   a
+#>         expr      min       lq      mean    median       uq      max neval  cld
+#>          cor   5.2296   5.5658   6.01588   5.85185   6.2553   7.2560    10 a   
+#>    correlate  43.2178  45.2571  49.23176  47.46405  52.1339  62.1109    10  b  
+#>  colpair_map 655.3740 695.4097 729.78595 722.32390 737.7867 882.0173    10    d
+#>     pairwise 245.2783 264.9519 277.95506 271.93135 295.3673 319.9610    10   c
 ```
 
 The `stats::cor()` and `corrr::correlate()` approaches are many times
@@ -196,3 +200,8 @@ based solution.)
 apples-to-apples comparison as both can handle arbitrary functions),
 though much of this speed difference goes away when
 `.is_commutative = FALSE`.
+
+# Limitations
+
+See issue [\#1](https://github.com/brshallo/pwiser/issues/1) for a
+little on limitations in current set-up.

--- a/docs/404.html
+++ b/docs/404.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pwiser</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.1.9000</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pwiser</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.1.9000</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pwiser</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.1.9000</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pwiser</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.1.9000</span>
       </span>
     </div>
 
@@ -66,6 +66,7 @@
 
       </header><div class="row">
   <div class="contents col-md-9">
+
 <div id="pwiser" class="section level1">
 <div class="page-header"><h1 class="hasAnchor">
 <a href="#pwiser" class="anchor"></a>pwiser</h1></div>
@@ -162,6 +163,8 @@
 <a href="#see-also" class="anchor"></a>See Also</h2>
 <p>There are other tools in R for doing tidy pairwise operations. <a href="https://github.com/dgrtwo/widyr">widyr</a> (by David Robinson) and <a href="https://github.com/tidymodels/corrr">corrr</a> (in the <code>tidymodels</code> suite) offer solutions (primarily) for summarising contexts (<code><a href="https://corrr.tidymodels.org/reference/colpair_map.html">corrr::colpair_map()</a></code> is the closest comparison as it also supports arbitrary functions). <code><a href="https://recipes.tidymodels.org/reference/step_ratio.html">recipes::step_ratio()</a></code> and <code><a href="https://recipes.tidymodels.org/reference/step_interact.html">recipes::step_interact()</a></code> can be used for making pairwise products or ratios in mutating contexts. (See Appendix section of prior blog post on <a href="https://www.bryanshalloway.com/2020/06/03/tidy-2-way-column-combinations/#tweets">Tidy Pairwise Operations</a> for a few cataloged tweets on these approaches.)</p>
 <p>The novelty of <code><a href="reference/pairwise.html">pwiser::pairwise()</a></code> is its integration in both mutating and summarising verbs in <a href="https://dplyr.tidyverse.org">dplyr</a>.</p>
+<p><strong>Identified after publishing {pwiser}:</strong></p>
+<p>The <a href="https://github.com/TimTeaFan/dplyover">dplyover</a> package is a more mature package that also offers a wide range of extensions on <code><a href="https://dplyr.tidyverse.org/reference/across.html">across()</a></code> for iteration problems. <code><a href="https://rdrr.io/pkg/dplyover/man/over2.html">dplyover::over2x()</a></code> can be used to do essentially the same thing as <code><a href="reference/pairwise.html">pairwise()</a></code>. We are currently reviewing whether to mark {pwiser} as superseded so we can point people to {dplyover}.</p>
 </div>
 <div id="computation-speed" class="section level2">
 <h2 class="hasAnchor">
@@ -189,20 +192,21 @@
   times <span class="op">=</span> <span class="fl">10L</span>,
   unit <span class="op">=</span> <span class="st">"ms"</span><span class="op">)</span>
 <span class="co">#&gt; Unit: milliseconds</span>
-<span class="co">#&gt;         expr      min       lq       mean    median        uq       max neval</span>
-<span class="co">#&gt;          cor   4.9390   5.4155    6.59767   6.23110    7.1104   10.0226    10</span>
-<span class="co">#&gt;    correlate  42.0968  42.4645   56.14318  53.70095   67.0191   77.7793    10</span>
-<span class="co">#&gt;  colpair_map 786.2960 833.6539 1119.77656 844.24510 1177.1455 2314.8609    10</span>
-<span class="co">#&gt;     pairwise 255.8610 266.7864  321.14781 300.37675  345.9385  495.8805    10</span>
-<span class="co">#&gt;  cld</span>
-<span class="co">#&gt;   a </span>
-<span class="co">#&gt;   a </span>
-<span class="co">#&gt;    b</span>
-<span class="co">#&gt;   a</span></code></pre></div>
+<span class="co">#&gt;         expr      min       lq      mean    median       uq      max neval  cld</span>
+<span class="co">#&gt;          cor   5.2296   5.5658   6.01588   5.85185   6.2553   7.2560    10 a   </span>
+<span class="co">#&gt;    correlate  43.2178  45.2571  49.23176  47.46405  52.1339  62.1109    10  b  </span>
+<span class="co">#&gt;  colpair_map 655.3740 695.4097 729.78595 722.32390 737.7867 882.0173    10    d</span>
+<span class="co">#&gt;     pairwise 245.2783 264.9519 277.95506 271.93135 295.3673 319.9610    10   c</span></code></pre></div>
 <p>The <code><a href="https://rdrr.io/r/stats/cor.html">stats::cor()</a></code> and <code><a href="https://corrr.tidymodels.org/reference/correlate.html">corrr::correlate()</a></code> approaches are many times faster than using <code><a href="reference/pairwise.html">pairwise()</a></code>. However <code><a href="reference/pairwise.html">pairwise()</a></code> still only takes about one fifth of a second to calculate 1540 correlations in this case. Hence on relatively constrained problems pairwise() is still quite usable. (Though there are many cases where you should go for a matrix based solution.)</p>
 <p><code><a href="reference/pairwise.html">pairwise()</a></code> seems to be faster than <code><a href="https://corrr.tidymodels.org/reference/colpair_map.html">corrr::colpair_map()</a></code> (a more apples-to-apples comparison as both can handle arbitrary functions), though much of this speed difference goes away when <code>.is_commutative = FALSE</code>.</p>
 </div>
 </div>
+<div id="limitations" class="section level1">
+<h1 class="hasAnchor">
+<a href="#limitations" class="anchor"></a>Limitations</h1>
+<p>See issue <a href="https://github.com/brshallo/pwiser/issues/1">#1</a> for a little on limitations in current set-up.</p>
+</div>
+
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,5 +2,5 @@ pandoc: 2.11.4
 pkgdown: 1.6.1
 pkgdown_sha: ~
 articles: {}
-last_built: 2021-05-13T15:59Z
+last_built: 2021-05-19T18:47Z
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pwiser</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.1.9000</span>
       </span>
     </div>
 

--- a/docs/reference/pairwise.html
+++ b/docs/reference/pairwise.html
@@ -75,7 +75,7 @@ used primarily within dplyr::mutate() and dplyr::summarise())." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pwiser</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.1.9000</span>
       </span>
     </div>
 

--- a/docs/reference/pwiser-package.html
+++ b/docs/reference/pwiser-package.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pwiser</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.1.9000</span>
       </span>
     </div>
 
@@ -119,6 +119,14 @@
 
 
 
+    <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
+
+    <div class='dont-index'><p>Useful links:</p><ul>
+<li><p><a href='https://github.com/brshallo/pwiser'>https://github.com/brshallo/pwiser</a></p></li>
+<li><p>Report bugs at <a href='https://github.com/brshallo/pwiser/issues'>https://github.com/brshallo/pwiser/issues</a></p></li>
+</ul>
+
+</div>
     <h2 class="hasAnchor" id="author"><a class="anchor" href="#author"></a>Author</h2>
 
     <p><strong>Maintainer</strong>: Bryan Shalloway <a href='mailto:brshallodev@gmail.com'>brshallodev@gmail.com</a></p>

--- a/man/pwiser-package.Rd
+++ b/man/pwiser-package.Rd
@@ -8,6 +8,14 @@
 \description{
 To learn more about pwiser see https://github.com/brshallo/pwiser
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/brshallo/pwiser}
+  \item Report bugs at \url{https://github.com/brshallo/pwiser/issues}
+}
+
+}
 \author{
 \strong{Maintainer}: Bryan Shalloway \email{brshallodev@gmail.com}
 


### PR DESCRIPTION
Should fix #9 .

Copy in most exported functions from @carlomedina original fork [carlomedina/dplyr](https://github.com/carlomedina/dplyr/tree/master/R). Most of these are in R/context.R

This on it's own did not fix things, also did hack that sets mask to dplyr (see `pwiser:::context_peek_bare()`). This is an absolute hack and means that checks on whether pairwise() is being used in appropriate contexts is no longer being checked...

Also updated README to add note about overlap with more mature package {dplyover} and limitations (pointing to #1).