### PR TITLE
Explore parallel pairwise computation with furrr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Imports:
     vctrs (>= 0.3.5), 
     pillar (>= 1.5.1),
     dplyr (>= 0.8.3),
-    purrr
+    purrr,
+    furrr
 Suggests: 
     bench,
     broom,


### PR DESCRIPTION
This actually results in much much slower execution in Windows. Not sure if forking will make it run faster (my assumption being that without forking, the data is being copied to the subprocesses and that takes longer than the calculation itself). 

https://cran.r-project.org/web/packages/future/vignettes/future-1-overview.html
From this link, RStudio (all OS) and Windows does not allow parallelization via forking.

```
Unit: milliseconds
              expr       min        lq       mean    median        uq       max neval
               cor    0.1523    0.1864    0.20064    0.1886    0.1905    0.2854     5
         correlate    1.8156    2.4104    2.48256    2.5657    2.7779    2.8432     5
       colpair_map   24.0201   24.9793   26.98626   25.2100   26.3402   34.3817     5
          pairwise    4.9847    6.0990    6.12044    6.3015    6.5251    6.6919     5
 pairwise_parallel 4931.4913 4934.7933 5753.84910 6122.5053 6337.2078 6443.2478     5
 ```

I don't think it's worth it to merge/make any changes in this area, especially most users use RStudio as their IDE.